### PR TITLE
Addheader overwrite modes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,14 @@ jobs:
       matrix:
         xcode:
           - latest
-          - latest-stable
-        platform:
-          - runner: macos-latest
-            destination: 'platform=macOS,arch=x86_64'
-          - runner: macos-11.0
-            destination: 'platform=macOS,arch=x86_64'
-          #- runner: macos-11.0
-          #  destination: 'platform=macOS,arch=arm64'
-          - runner: macos-latest
-            destination: 'platform=iOS Simulator,OS=latest,name=iPhone 11 Pro'
-          - runner: macos-latest
-            destination: 'platform=tvOS Simulator,OS=latest,name=Apple TV 4K'
-    runs-on: ${{ matrix.platform.runner }}
+          #- latest-stable
+        destination:
+          - 'platform=macOS,arch=x86_64'
+          #- 'platform=macOS,arch=arm64'
+          - 'platform=iOS Simulator,OS=latest,name=iPhone 11 Pro'
+          - 'platform=tvOS Simulator,OS=latest,name=Apple TV 4K'
+          - 'platform=watchOS Simulator,OS=latest,name=Apple Watch Series 6 - 44mm'
+    runs-on: macos-11.0
     steps:
     - name: Select latest available Xcode
       uses: maxim-lobanov/setup-xcode@v1
@@ -32,8 +27,8 @@ jobs:
         xcode-version: ${{ matrix.xcode }}
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Run tests for ${{ matrix.platform.destination }}
-      run: xcodebuild test -scheme NetworkClient-Package -enableThreadSanitizer YES -destination '${{ matrix.platform.destination }}'
+    - name: Run tests for ${{ matrix.destination }}
+      run: xcodebuild test -scheme NetworkClient-Package -enableThreadSanitizer YES -destination '${{ matrix.destination }}'
   
   linux:
     runs-on: ubuntu-20.04
@@ -41,14 +36,13 @@ jobs:
       fail-fast: false
       matrix:
         ver:
-          - 5.2
-          - 5.3
+          - swift:5.3
+          - swiftlang/swift:nightly-5.3
+          - swiftlang/swift:nightly-5.4
+          - swiftlang/swift:nightly-main
         os:
-          - xenial
           - bionic
           - focal
-          #- centos7
-          - centos8
           - amazonlinux2
     container:
       image: swift:${{ matrix.ver }}-${{ matrix.os }}
@@ -65,7 +59,7 @@ jobs:
         uses: seanmiddleditch/gha-setup-vsdevenv@master
       - name: Install Swift snapshot
         run: |
-          Install-Binary -Url "https://swift.org/builds/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2021-01-17-a/swift-DEVELOPMENT-SNAPSHOT-2021-01-17-a-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          Install-Binary -Url "https://swift.org/builds/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2021-02-18-a/swift-DEVELOPMENT-SNAPSHOT-2021-02-18-a-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
       - name: Set Environment Variables
         run: |
           echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           - focal
           - amazonlinux2
     container:
-      image: swift:${{ matrix.ver }}-${{ matrix.os }}
+      image: ${{ matrix.ver }}-${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Network Client open source project

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
 </a>
 <a href="https://swift.org">
-    <img src="https://img.shields.io/badge/swift-5.2-brightgreen.svg" alt="Swift 5.2">
+    <img src="https://img.shields.io/badge/swift-5.3-brightgreen.svg" alt="Swift 5.3">
 </a>
 <a href="https://github.com/stairtree/NetworkClient/actions">
     <img src="https://github.com/stairtree/NetworkClient/workflows/test/badge.svg" alt="CI">
@@ -18,10 +18,11 @@ A testable and composable network client.
 NetworkClient is tested on macOS, iOS, tvOS, Linux, and Windows, and is known to support the following operating system versions:
 
 * Ubuntu 16.04+
+* AmazonLinux2
 * macOS 10.12+
 * iOS 12+
 * tvOS 12+
-* watchOS (untested since watchOS doesn't support `XCTest`)
+* watchOS 7+
 * Windows 10 (using the latest Swift development snapshot)
 
 To integrate the package:

--- a/Sources/NetworkClient/Transport/AddHeaders.swift
+++ b/Sources/NetworkClient/Transport/AddHeaders.swift
@@ -19,28 +19,59 @@ import FoundationNetworking
 /// Add headers to an existing `Transport`.
 public final class AddHeaders: Transport {
     
+    /// An enumeration of the possible modes for working with headers.
+    public enum Mode: CaseIterable {
+        /// Accumulating behavior - if a given header is already specified by a request, the transport's value is
+        /// appended, as per `URLRequest.addValue(_:forHTTPHeaderField:)`.
+        ///
+        /// - Note: This is rarely what you want, but it was the default behavior before this mechanism was added, and
+        ///   thus remains the default.
+        case append
+        
+        /// Overwriting behavior - if a given header is already specified by a request, the transport's value for the
+        /// header replaces it, as per `URLRequest.setValue(_:forHTTPHeaderField:)`. In this mode, a request's header
+        /// value is always overwritten.
+        case replace
+        
+        /// Polyfill behavior - if a given header is already specified by a request, it is left untouched, and the
+        /// transport's value is ignored.
+        case add
+    }
+    
     /// The base `Transport` to extend with extra headers
     private let base: Transport
     
     /// Additional headers that will be applied to the request upon sending.
     private let headers: [String: String]
 
+    /// The mode used to add additional headers. Defaults to `.append` for legacy compatibility.
+    private let mode: Mode
     
     /// Create a `Transport` that adds headers to the base `Transport`
     /// - Parameters:
     ///   - base: The base `Transport` that will have the headers applied
     ///   - headers: Headers to apply to the base `Transport`
-    ///
-    /// - Note: Existing headers with the same keys will be overwritten
-
-    public init(base: Transport, headers: [String: String]) {
+    ///   - mode: The mode to use for resolving conflicts between a request's headers and the transport's headers.
+    public init(base: Transport, headers: [String: String], mode: Mode = .append) {
         self.base = base
         self.headers = headers
+        self.mode = mode
     }
 
     public func send(request: URLRequest, completion: @escaping (Response) -> Void) {
         var newRequest = request
-        for (key, value) in headers { newRequest.addValue(value, forHTTPHeaderField: key) }
+
+        for (key, value) in self.headers {
+            switch self.mode {
+                case .replace:
+                    newRequest.setValue(value, forHTTPHeaderField: key)
+                case .add:
+                    guard newRequest.value(forHTTPHeaderField: key) == nil else { break }
+                    fallthrough
+                case .append:
+                    newRequest.addValue(value, forHTTPHeaderField: key)
+            }
+        }
         base.send(request: newRequest, completion: completion)
     }
 }

--- a/Sources/NetworkClient/Transport/AddHeaders.swift
+++ b/Sources/NetworkClient/Transport/AddHeaders.swift
@@ -24,8 +24,7 @@ public final class AddHeaders: Transport {
         /// Accumulating behavior - if a given header is already specified by a request, the transport's value is
         /// appended, as per `URLRequest.addValue(_:forHTTPHeaderField:)`.
         ///
-        /// - Note: This is rarely what you want, but it was the default behavior before this mechanism was added, and
-        ///   thus remains the default.
+        /// - Warning: This is rarely what you want.
         case append
         
         /// Overwriting behavior - if a given header is already specified by a request, the transport's value for the
@@ -35,6 +34,8 @@ public final class AddHeaders: Transport {
         
         /// Polyfill behavior - if a given header is already specified by a request, it is left untouched, and the
         /// transport's value is ignored.
+        ///
+        /// This behavior is the default.
         case add
     }
     
@@ -52,7 +53,7 @@ public final class AddHeaders: Transport {
     ///   - base: The base `Transport` that will have the headers applied
     ///   - headers: Headers to apply to the base `Transport`
     ///   - mode: The mode to use for resolving conflicts between a request's headers and the transport's headers.
-    public init(base: Transport, headers: [String: String], mode: Mode = .append) {
+    public init(base: Transport, headers: [String: String], mode: Mode = .add) {
         self.base = base
         self.headers = headers
         self.mode = mode

--- a/Sources/NetworkClientTestSupport/TestRequest.swift
+++ b/Sources/NetworkClientTestSupport/TestRequest.swift
@@ -17,6 +17,8 @@ import FoundationNetworking
 #endif
 import NetworkClient
 
+/// A `NetworkRequest` that simply requests the base URL (optionally with additional headers added) and expects UTF-8
+/// `String`s as responses.
 public struct TestRequest: NetworkRequest {
     private let extraHeaders: [String: String]
     

--- a/Sources/NetworkClientTestSupport/TestRequest.swift
+++ b/Sources/NetworkClientTestSupport/TestRequest.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Network Client open source project
+//
+// Copyright (c) Stairtree GmbH
+// Licensed under the MIT license
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import NetworkClient
+
+public struct TestRequest: NetworkRequest {
+    private let extraHeaders: [String: String]
+    
+    public init(extraHeaders: [String: String] = [:]) {
+        self.extraHeaders = extraHeaders
+    }
+    
+    public func makeRequest(baseURL: URL) throws -> URLRequest {
+        var request = URLRequest(url: baseURL)
+        extraHeaders.forEach { request.addValue($1, forHTTPHeaderField: $0) }
+        return request
+    }
+
+    public func parseResponse(_ data: Data) throws -> String {
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Tests/NetworkClientTests/NetworkClientTests.swift
+++ b/Tests/NetworkClientTests/NetworkClientTests.swift
@@ -18,112 +18,112 @@ import FoundationNetworking
 import NetworkClient
 import NetworkClientTestSupport
 
+struct TestRequest: NetworkRequest {
+    let extraHeaders: [String: String]
+    
+    init(extraHeaders: [String: String] = [:]) {
+        self.extraHeaders = extraHeaders
+    }
+    
+    func makeRequest(baseURL: URL) throws -> URLRequest {
+        var request = URLRequest(url: baseURL)
+        extraHeaders.forEach { request.addValue($1, forHTTPHeaderField: $0) }
+        return request
+    }
+
+    func parseResponse(_ data: Data) throws -> String {
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
 final class NetworkClientTests: XCTestCase {
+    private static let baseTestURL = URL(string: "https://test.somewhere.com")!
+    
+    private func _runTest<R: NetworkRequest>(
+        request: R, client: NetworkClient,
+        file: StaticString = #filePath, line: UInt = #line
+    ) throws -> Result<R.ResponseDataType, Error> {
+        let expectation = XCTestExpectation(description: "network client completion expectation")
+        var rawResult: Result<R.ResponseDataType, Error>?
+        
+        XCTAssertEqual(client.baseURL, Self.baseTestURL)
+        client.load(request) { actualResult in
+            rawResult = actualResult
+            expectation.fulfill()
+        }
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [expectation], timeout: 5.0), XCTWaiter.Result.completed,
+            "Test network request timeout", file: file, line: line
+        )
+        return try XCTUnwrap(rawResult, "No result after network request completed", file: file, line: line)
+    }
+    
+    private func runTest<R>(
+        request: R, client: NetworkClient, expecting expectedResponse: R.ResponseDataType,
+        file: StaticString = #filePath, line: UInt = #line
+    ) throws where R: NetworkRequest, R.ResponseDataType: Equatable {
+        switch try self._runTest(request: request, client: client) {
+            case .success(let response):
+                XCTAssertEqual(response, expectedResponse, file: file, line: line)
+            case let result:
+                XCTFail("Expected success response \(expectedResponse), but got \(result)", file: file, line: line)
+        }
+    }
+
+    private func runTest<R, E>(
+        request: R, client: NetworkClient, expecting expectedError: E,
+        file: StaticString = #filePath, line: UInt = #line
+    ) throws where R: NetworkRequest, E: Error, E: Equatable {
+        switch try self._runTest(request: request, client: client) {
+            case .failure(let rawError):
+                let error = try XCTUnwrap(rawError as? E, "Unexpected error \(rawError)", file: file, line: line)
+                XCTAssertEqual(error, expectedError, file: file, line: line)
+            case let result:
+                XCTFail("Expected failure response \(expectedError), but got \(result)", file: file, line: line)
+        }
+    }
 
     func testNetworkClient() throws {
-
-        struct TestRequest: NetworkRequest {
-            func makeRequest(baseURL: URL) throws -> URLRequest {
-                return URLRequest(url: baseURL)
-            }
-
-            func parseResponse(_ data: Data) throws -> String {
-                return String(decoding: data, as: UTF8.self)
-            }
-        }
-
         let response: Response = .success(Data("Test".utf8))
-
         let requestAssertions: (URLRequest) -> Void = {
             XCTAssertEqual($0.url, URL(string: "https://test.somewhere.com")!)
         }
-
-        let client = NetworkClient(baseURL: URL(string: "https://test.somewhere.com")!, transport: TestTransport(responses: [response], assertRequest: requestAssertions))
-
-
-        client.load(TestRequest()) { result in
-            do {
-                let response = try result.get()
-                XCTAssertEqual(response, "Test")
-            } catch {
-                XCTFail("\(error)")
-            }
-        }
-
-        XCTAssertEqual(client.baseURL.absoluteString, "https://test.somewhere.com")
+        let client = NetworkClient(baseURL: Self.baseTestURL, transport: TestTransport(responses: [response], assertRequest: requestAssertions))
+        
+        try self.runTest(request: TestRequest(), client: client, expecting: "Test")
     }
 
-    func testTokenAuth() {
-        struct TestRequest: NetworkRequest {
-            func makeRequest(baseURL: URL) throws -> URLRequest { URLRequest(url: baseURL) }
-            func parseResponse(_ data: Data) throws -> String { String(decoding: data, as: UTF8.self) }
-        }
-
+    func testTokenAuth() throws {
         let accessToken = TestToken(raw: "abc", expiresAt: Date())
         let refreshToken = TestToken(raw: "def", expiresAt: Date())
-
         let tokenProvider = TestTokenProvider(accessToken: accessToken, refreshToken: refreshToken)
-
         let response: Response = .success(Data("Test".utf8))
-
         let requestAssertions: (URLRequest) -> Void = {
             XCTAssertEqual($0.url, URL(string: "https://test.somewhere.com")!)
             XCTAssertEqual($0.allHTTPHeaderFields?["Authorization"], "Bearer abc")
         }
-
-        let client = NetworkClient(baseURL: URL(string: "https://test.somewhere.com")!, transport:
+        let client = NetworkClient(baseURL: Self.baseTestURL, transport:
             TokenAuth(
                 base: TestTransport(responses: [response], assertRequest: requestAssertions),
                 tokenProvider: tokenProvider
             )
         )
-
-        client.load(TestRequest()) { result in
-            do {
-                let response = try result.get()
-                XCTAssertEqual(response, "Test")
-            } catch {
-                XCTFail("\(error)")
-            }
-        }
-
-        XCTAssertEqual(client.baseURL.absoluteString, "https://test.somewhere.com")
+        
+        try self.runTest(request: TestRequest(), client: client, expecting: "Test")
     }
     
-    func testStackingHeaders() {
-        struct TestRequest: NetworkRequest {
-            func makeRequest(baseURL: URL) throws -> URLRequest {
-                return URLRequest(url: baseURL)
-            }
-
-            func parseResponse(_ data: Data) throws -> String {
-                return String(decoding: data, as: UTF8.self)
-            }
-        }
-
+    func testStackingHeaders() throws {
         let response: Response = .success(Data("Test".utf8))
-
         let requestAssertions: (URLRequest) -> Void = {
             XCTAssertEqual($0.url, URL(string: "https://test.somewhere.com")!)
             XCTAssertEqual($0.allHTTPHeaderFields?["H1"], "1")
             XCTAssertEqual($0.allHTTPHeaderFields?["H2"], "2")
         }
-
         let base = TestTransport(responses: [response], assertRequest: requestAssertions)
         let h1 = AddHeaders(base: base, headers: ["H1": "1"])
         let h2 = AddHeaders(base: h1, headers: ["H2": "2"])
+        let client = NetworkClient(baseURL: Self.baseTestURL, transport: h2)
         
-        let client = NetworkClient(baseURL: URL(string: "https://test.somewhere.com")!, transport: h2)
-
-        client.load(TestRequest()) { result in
-            do {
-                let response = try result.get()
-                XCTAssertEqual(response, "Test")
-            } catch {
-                XCTFail("\(error)")
-            }
-        }
-
-        XCTAssertEqual(client.baseURL.absoluteString, "https://test.somewhere.com")
+        try self.runTest(request: TestRequest(), client: client, expecting: "Test")
     }
 }

--- a/Tests/NetworkClientTests/NetworkClientTests.swift
+++ b/Tests/NetworkClientTests/NetworkClientTests.swift
@@ -18,24 +18,6 @@ import FoundationNetworking
 import NetworkClient
 import NetworkClientTestSupport
 
-struct TestRequest: NetworkRequest {
-    let extraHeaders: [String: String]
-    
-    init(extraHeaders: [String: String] = [:]) {
-        self.extraHeaders = extraHeaders
-    }
-    
-    func makeRequest(baseURL: URL) throws -> URLRequest {
-        var request = URLRequest(url: baseURL)
-        extraHeaders.forEach { request.addValue($1, forHTTPHeaderField: $0) }
-        return request
-    }
-
-    func parseResponse(_ data: Data) throws -> String {
-        return String(decoding: data, as: UTF8.self)
-    }
-}
-
 final class NetworkClientTests: XCTestCase {
     private static let baseTestURL = URL(string: "https://test.somewhere.com")!
     

--- a/Tests/NetworkClientTests/NetworkClientTests.swift
+++ b/Tests/NetworkClientTests/NetworkClientTests.swift
@@ -131,13 +131,29 @@ final class NetworkClientTests: XCTestCase {
         let response: Response = .success(Data("Test".utf8))
         let requestAssertions: (URLRequest) -> Void = {
             XCTAssertEqual($0.url, URL(string: "https://test.somewhere.com")!)
-            XCTAssertEqual($0.allHTTPHeaderFields?["H1"], "1-3,1-2,1-1")
+            XCTAssertEqual($0.allHTTPHeaderFields?["H1"], "1-3")
             XCTAssertEqual($0.allHTTPHeaderFields?["H2"], "2")
         }
         let base = TestTransport(responses: [response], assertRequest: requestAssertions)
         let h1_1 = AddHeaders(base: base, headers: ["H1": "1-1"])
         let h1_2 = AddHeaders(base: h1_1, headers: ["H1": "1-2"])
         let h2 = AddHeaders(base: h1_2, headers: ["H2": "2"])
+        let client = NetworkClient(baseURL: Self.baseTestURL, transport: h2)
+        
+        try self.runTest(request: TestRequest(extraHeaders: ["H1": "1-3"]), client: client, expecting: "Test")
+    }
+
+    func testConflictingHeaderAddMode() throws {
+        let response: Response = .success(Data("Test".utf8))
+        let requestAssertions: (URLRequest) -> Void = {
+            XCTAssertEqual($0.url, URL(string: "https://test.somewhere.com")!)
+            XCTAssertEqual($0.allHTTPHeaderFields?["H1"], "1-3")
+            XCTAssertEqual($0.allHTTPHeaderFields?["H2"], "2")
+        }
+        let base = TestTransport(responses: [response], assertRequest: requestAssertions)
+        let h1_1 = AddHeaders(base: base, headers: ["H1": "1-1"], mode: .add)
+        let h1_2 = AddHeaders(base: h1_1, headers: ["H1": "1-2"], mode: .add)
+        let h2 = AddHeaders(base: h1_2, headers: ["H2": "2"], mode: .add)
         let client = NetworkClient(baseURL: Self.baseTestURL, transport: h2)
         
         try self.runTest(request: TestRequest(extraHeaders: ["H1": "1-3"]), client: client, expecting: "Test")
@@ -170,22 +186,6 @@ final class NetworkClientTests: XCTestCase {
         let h1_1 = AddHeaders(base: base, headers: ["H1": "1-1"], mode: .replace)
         let h1_2 = AddHeaders(base: h1_1, headers: ["H1": "1-2"], mode: .replace)
         let h2 = AddHeaders(base: h1_2, headers: ["H2": "2"], mode: .replace)
-        let client = NetworkClient(baseURL: Self.baseTestURL, transport: h2)
-        
-        try self.runTest(request: TestRequest(extraHeaders: ["H1": "1-3"]), client: client, expecting: "Test")
-    }
-
-    func testConflictingHeaderAddMode() throws {
-        let response: Response = .success(Data("Test".utf8))
-        let requestAssertions: (URLRequest) -> Void = {
-            XCTAssertEqual($0.url, URL(string: "https://test.somewhere.com")!)
-            XCTAssertEqual($0.allHTTPHeaderFields?["H1"], "1-3")
-            XCTAssertEqual($0.allHTTPHeaderFields?["H2"], "2")
-        }
-        let base = TestTransport(responses: [response], assertRequest: requestAssertions)
-        let h1_1 = AddHeaders(base: base, headers: ["H1": "1-1"], mode: .add)
-        let h1_2 = AddHeaders(base: h1_1, headers: ["H1": "1-2"], mode: .add)
-        let h2 = AddHeaders(base: h1_2, headers: ["H2": "2"], mode: .add)
         let client = NetworkClient(baseURL: Self.baseTestURL, transport: h2)
         
         try self.runTest(request: TestRequest(extraHeaders: ["H1": "1-3"]), client: client, expecting: "Test")


### PR DESCRIPTION
Add ability to specify a "mode" for the `AddHeaders` transport telling it how to handle conflicts between the headers it sets and headers already set in the request.

Also does a little test refactoring.