### PR TITLE
Add simple cancellation

### DIFF
--- a/Sources/NetworkClient/Transport/AddHeaders.swift
+++ b/Sources/NetworkClient/Transport/AddHeaders.swift
@@ -75,4 +75,6 @@ public final class AddHeaders: Transport {
         }
         base.send(request: newRequest, completion: completion)
     }
+    
+    public var next: Transport? { base }
 }

--- a/Sources/NetworkClient/Transport/TokenAuth.swift
+++ b/Sources/NetworkClient/Transport/TokenAuth.swift
@@ -42,6 +42,8 @@ public final class TokenAuth: Transport {
             }
         }
     }
+    
+    public var next: Transport? { base }
 }
 
 public protocol TokenProvider {

--- a/Sources/NetworkClientTestSupport/TestTransport.swift
+++ b/Sources/NetworkClientTestSupport/TestTransport.swift
@@ -37,4 +37,6 @@ public final class TestTransport: Transport {
             completion(.failure(status: .tooManyRequests, body: Data()))
         }
     }
+    
+    public var next: Transport? { nil }
 }


### PR DESCRIPTION
Add `cancel()` and `next: Transport?` to Transport requirements. This also requires wrapping URLSession to allow it as Transport.