### PR TITLE
Per request transport

### DIFF
--- a/Sources/NetworkClient/NetworkClient+Combine.swift
+++ b/Sources/NetworkClient/NetworkClient+Combine.swift
@@ -41,7 +41,7 @@ extension NetworkClient {
             
             // Send it to the transport
             return Future<Request.ResponseDataType, Error> { completion in
-                self.transport.send(request: urlRequest, completion: { response in
+                self.transport().send(request: urlRequest, completion: { response in
                     let result = Result(catching: { try handleResponse(response) })
                     completion(result)
                 })

--- a/Sources/NetworkClient/NetworkClient.swift
+++ b/Sources/NetworkClient/NetworkClient.swift
@@ -88,10 +88,10 @@ extension NetworkRequest {
 
 public final class NetworkClient {
     public let baseURL: URL
-    let transport: Transport
+    let transport: () -> Transport
     let logger: Logger
 
-    public init(baseURL: URL, transport: Transport = URLSessionTransport(.shared), logger: Logger? = nil) {
+    public init(baseURL: URL, transport: @escaping @autoclosure () -> Transport = URLSessionTransport(.shared), logger: Logger? = nil) {
         self.baseURL = baseURL
         self.transport = transport
         self.logger = logger ?? Logger(label: "NetworkClient")
@@ -106,7 +106,7 @@ public final class NetworkClient {
             logger.trace(Logger.Message(stringLiteral: urlRequest.debugString))
 
             // Send it to the transport
-            transport.send(request: urlRequest) { response in
+            transport().send(request: urlRequest) { response in
                 // TODO: Deliver a more accurate split of the different phases of the request
                 defer { self.logger.trace("Request '\(urlRequest.debugString)' took \(String(format: "%.4f", milliseconds(from: start, to: .now())))ms") }
                 

--- a/Sources/NetworkClient/Transport/BackgroundTaskTransport.swift
+++ b/Sources/NetworkClient/Transport/BackgroundTaskTransport.swift
@@ -17,7 +17,7 @@ import FoundationNetworking
 #endif
 import Logging
 
-#if !os(macOS)
+#if !os(macOS) && canImport(UIKit)
 import UIKit
 
 public final class BackgroundExtendingTransport: Transport {

--- a/Sources/NetworkClient/Transport/BackgroundTaskTransport.swift
+++ b/Sources/NetworkClient/Transport/BackgroundTaskTransport.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Network Client open source project
+//
+// Copyright (c) Stairtree GmbH
+// Licensed under the MIT license
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Logging
+
+#if !os(macOS)
+import UIKit
+
+public final class BackgroundExtendingTransport: Transport {
+    
+    /// The base `Transport` to extend
+    private let base: Transport
+    
+    /// A debug name for the background task. It will be suffixed with the request's url
+    private let name: String?
+    
+    /// Called synchronously on the main thread shortly before the app is suspended
+    private let expirationHandler: (() -> Void)?
+    
+    private var started: Bool = false
+    
+    public init(base: Transport, name: String?, expirationHandler: (() -> Void)?) {
+        self.base = base
+        self.name = name
+        self.expirationHandler = expirationHandler
+    }
+    
+    public func send(request: URLRequest, completion: @escaping (Response) -> Void) {
+        if #available(
+            iOSApplicationExtension 9,
+            tvOSApplicationExtension 9,
+            macCatalystApplicationExtension 13,
+            watchOS 2,
+            iOS 999, tvOS 999, macCatalyst 999, *
+        ) {
+            let reason = request.debugString
+            ProcessInfo().performExpiringActivity(withReason: reason, using: { expired in
+                // Being called with `expired` without being `started` means
+                // the background assertion was not granted.
+                if expired && !self.started { self.cancel(); return completion(.error(.cancelled)) }
+                self.started = true
+                guard !expired else { return self.cancel() }
+                self.base.send(request: request, completion: completion)
+            })
+        } else {
+            #if !os(watchOS)
+            let reason = "\(name.map { "\($0)-" } ?? "")\(request.debugString)"
+            var identifier: UIBackgroundTaskIdentifier!
+            identifier = UIApplication.shared.beginBackgroundTask(withName: reason, expirationHandler: { [weak self] in
+                self?.expirationHandler?()
+                UIApplication.shared.endBackgroundTask(identifier)
+            })
+            guard identifier != .invalid else { self.cancel(); return completion(.error(.cancelled)) }
+            base.send(request: request) { response in
+                completion(response)
+                UIApplication.shared.endBackgroundTask(identifier)
+            }
+            #endif
+        }
+    }
+    
+    public var next: Transport? { base }
+}
+#endif


### PR DESCRIPTION
Makes the `Transport` parameter an autoclosure that is executed on every request.

Also adds a sample `Transport` that tries to extend the lifetime of an app or extension for the duration of the request as an example for why "per request" `Transport`s are useful.

Cancellation for that case is a bit questionable, as the caller needs to provide an expiration handler anyway, in which the caller could also call cancel manually.